### PR TITLE
!feat: add CPE format validation in property setter

### DIFF
--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -23,6 +23,7 @@ from warnings import warn
 
 # See https://github.com/package-url/packageurl-python/issues/65
 import serializable
+from cpe import CPE  # type:ignore
 from packageurl import PackageURL
 from sortedcontainers import SortedSet
 
@@ -1457,6 +1458,11 @@ class Component(Dependable):
 
     @cpe.setter
     def cpe(self, cpe: Optional[str]) -> None:
+        if cpe:
+            try:
+                CPE(cpe)
+            except NotImplementedError:
+                raise ValueError(f'Invalid CPE format: {cpe}')
         self._cpe = cpe
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ sortedcontainers = "^2.4.0"
 license-expression = "^30"
 jsonschema = { version = "^4.18", extras=['format'], optional=true }
 lxml = { version=">=4,<6", optional=true }
+cpe = "^1.3.1"
 
 [tool.poetry.extras]
 validation = ["jsonschema", "lxml"]

--- a/tests/test_model_component.py
+++ b/tests/test_model_component.py
@@ -283,6 +283,16 @@ class TestModelComponent(TestCase):
         self.assertEqual(3, len(comp_b.get_all_nested_components(include_self=True)))
         self.assertEqual(2, len(comp_b.get_all_nested_components(include_self=False)))
 
+    def test_cpe_validation_valid_format(self) -> None:
+        cpe = 'cpe:2.3:a:python:setuptools:50.3.2:*:*:*:*:*:*:*'
+        c = Component(name='test-component', cpe=cpe)
+        self.assertEqual(c.cpe, cpe)
+
+    def test_cpe_validation_invalid_format(self) -> None:
+        invalid_cpe = 'invalid-cpe-string'
+        with self.assertRaises(ValueError):
+            Component(name='test-component', cpe=invalid_cpe)
+
 
 class TestModelComponentEvidence(TestCase):
 


### PR DESCRIPTION
- Implemented validation of CPE format using [CPE](https://github.com/nilp0inter/cpe) library
- Added tests to verify the handling of invalid CPE strings.


Note: 
- The CPE library is missing library stubs or py.typed marker, not sure how you want to handle it. I used type:ignore.
- CPE library raises NotImplementedErorr for incorrect CPE Name or version [link](https://github.com/nilp0inter/cpe/blob/50ba2ee28b5d6b24fa2c5b1493de9de953ca7dce/cpe/cpe2_3.py#L80)
