### PR TITLE
Store Component.purl as normalized string and accept castable objects

### DIFF
--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -19,7 +19,7 @@ import re
 import sys
 from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any, Optional, Protocol, Union
 from warnings import warn
 
 if sys.version_info >= (3, 13):
@@ -33,7 +33,7 @@ from packageurl import PackageURL
 from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str
-from .._internal.compare import ComparablePackageURL as _ComparablePackageURL, ComparableTuple as _ComparableTuple
+from .._internal.compare import ComparableTuple as _ComparableTuple
 from ..exception.model import InvalidOmniBorIdException, InvalidSwhidException
 from ..exception.serialization import (
     CycloneDxDeserializationException,
@@ -50,7 +50,6 @@ from ..schema.schema import (
     SchemaVersion1Dot6,
     SchemaVersion1Dot7,
 )
-from ..serialization import PackageUrl as PackageUrlSH
 from . import (
     AttachedText,
     ExternalReference,
@@ -949,6 +948,13 @@ class Swhid(serializable.helpers.BaseHelper):
         return self._id
 
 
+
+
+class _StringCastable(Protocol):
+
+    def __str__(self) -> str: ...
+
+
 @serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Component(Dependable):
     """
@@ -995,7 +1001,7 @@ class Component(Dependable):
         hashes: Optional[Iterable[HashType]] = None,
         licenses: Optional[Iterable[License]] = None,
         copyright: Optional[str] = None,
-        purl: Optional[PackageURL] = None,
+        purl: Optional[_StringCastable] = None,
         external_references: Optional[Iterable[ExternalReference]] = None,
         properties: Optional[Iterable[Property]] = None,
         release_notes: Optional[ReleaseNotes] = None,
@@ -1377,9 +1383,9 @@ class Component(Dependable):
         self._cpe = cpe
 
     @property
-    @serializable.type_mapping(PackageUrlSH)
     @serializable.xml_sequence(15)
-    def purl(self) -> Optional[PackageURL]:
+    @serializable.xml_string(serializable.XmlStringSerializationType.NORMALIZED_STRING)
+    def purl(self) -> Optional[str]:
         """
         Specifies the package-url (PURL).
 
@@ -1387,13 +1393,13 @@ class Component(Dependable):
         https://github.com/package-url/purl-spec
 
         Returns:
-            `PackageURL` or `None`
+            `str` or `None`
         """
         return self._purl
 
     @purl.setter
-    def purl(self, purl: Optional[PackageURL]) -> None:
-        self._purl = purl
+    def purl(self, purl: Optional[_StringCastable]) -> None:
+        self._purl = None if purl is None else str(purl)
 
     @property
     @serializable.json_name('omniborId')
@@ -1680,7 +1686,7 @@ class Component(Dependable):
         return _ComparableTuple((
             self.type, self.group, self.name, self.version,
             self.bom_ref.value,
-            None if self.purl is None else _ComparablePackageURL(self.purl),
+            self.purl,
             self.swid, self.cpe, _ComparableTuple(self.swhids),
             self.supplier, self.author, self.publisher,
             self.description,

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -550,7 +550,7 @@ def get_bom_with_component_setuptools_with_vulnerability() -> Bom:
         ),
         affects=[
             BomTarget(
-                ref=component.purl.to_string(),
+                ref=str(component.purl),
                 versions=[BomTargetVersionRange(
                     range='49.0.0 - 54.0.0', status=ImpactAnalysisAffectedStatus.AFFECTED
                 )]

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -31,9 +31,7 @@ class TestComponent(TestCase):
 
     def test_purl_correct(self) -> None:
         self.assertEqual(
-            PackageURL(
-                type='pypi', name='setuptools', version='50.3.2', qualifiers='extension=tar.gz'
-            ),
+            'pkg:pypi/setuptools@50.3.2?extension=tar.gz',
             get_component_setuptools_simple().purl
         )
 
@@ -72,5 +70,12 @@ class TestComponent(TestCase):
         purl = PackageURL(
             type='generic', name='fixtures/bom_setuptools.xml', version=expected_version
         )
-        self.assertEqual(c.purl, purl)
+        self.assertEqual(c.purl, str(purl))
         self.assertEqual(len(c.hashes), 1)
+
+
+    def test_purl_casted_to_string(self) -> None:
+        purl = PackageURL(type='pypi', name='example', version='1.2.3')
+        component = Component(name='example', purl=purl)
+
+        self.assertEqual(component.purl, str(purl))


### PR DESCRIPTION
### Motivation

- Simplify serialization and equality handling of component package URLs by storing PURLs as normalized strings instead of `PackageURL` objects.

### Description

- Introduced a `_StringCastable` `Protocol` and changed the `Component` constructor to accept `purl: Optional[_StringCastable]` and cast it to `str` on assignment.
- Updated the `purl` property to return `Optional[str]`, added `@serializable.xml_string(serializable.XmlStringSerializationType.NORMALIZED_STRING)`, and removed the previous package-url-specific serialization mapping.
- Removed `_ComparablePackageURL` usage and the `PackageUrl` serialization helper import, and updated the component comparable tuple to use `self.purl` directly.
- Adjusted tests and test data to compare `purl` values as strings and added `test_purl_casted_to_string` to ensure `PackageURL` instances are correctly cast to `str` when assigned.
