### PR TITLE
feat(validation): improve user-facing schema validation errors

### DIFF
--- a/cyclonedx/validation/__init__.py
+++ b/cyclonedx/validation/__init__.py
@@ -37,14 +37,23 @@ class ValidationError:
     data: Any
     """Raw error data from one of the underlying validation methods."""
 
-    def __init__(self, data: Any) -> None:
+    message: str
+    """Human-readable error message suitable for end-user presentation."""
+
+    path: tuple[Union[str, int], ...]
+    """Path to the offending value if known."""
+
+    def __init__(self, data: Any, *, message: Optional[str] = None,
+                 path: Iterable[Union[str, int]] = ()) -> None:
         self.data = data
+        self.message = str(data) if message is None else message
+        self.path = tuple(path)
 
     def __repr__(self) -> str:
-        return repr(self.data)
+        return f'{self.__class__.__name__}(message={self.message!r}, path={self.path!r})'
 
     def __str__(self) -> str:
-        return str(self.data)
+        return self.message
 
 
 class SchemabasedValidator(Protocol):

--- a/cyclonedx/validation/json.py
+++ b/cyclonedx/validation/json.py
@@ -57,10 +57,23 @@ except ImportError as err:
 
 class JsonValidationError(ValidationError):
     @classmethod
+    def __get_most_relevant_jsve(cls, e: 'JsonSchemaValidationError') -> 'JsonSchemaValidationError':
+        if not e.context:
+            return e
+        # nested `context` errors generally provide more useful details than
+        # generic parent messages, e.g. for oneOf/anyOf checks.
+        child = max(e.context, key=lambda ce: len(ce.absolute_path))
+        return cls.__get_most_relevant_jsve(child)
+
+    @classmethod
     def _make_from_jsve(cls, e: 'JsonSchemaValidationError') -> 'JsonValidationError':
         """⚠️ This is an internal API. It is not part of the public interface and may change without notice."""
-        # in preparation for https://github.com/CycloneDX/cyclonedx-python-lib/pull/836
-        return cls(e)
+        useful = cls.__get_most_relevant_jsve(e)
+        return cls(
+            e,
+            message=useful.message,
+            path=tuple(useful.absolute_path)
+        )
 
 
 class _BaseJsonValidator(BaseSchemabasedValidator, ABC):

--- a/cyclonedx/validation/xml.py
+++ b/cyclonedx/validation/xml.py
@@ -51,8 +51,7 @@ class XmlValidationError(ValidationError):
     @classmethod
     def _make_from_xle(cls, e: '_XmlLogEntry') -> 'XmlValidationError':
         """⚠️ This is an internal API. It is not part of the public interface and may change without notice."""
-        # in preparation for https://github.com/CycloneDX/cyclonedx-python-lib/pull/836
-        return cls(e)
+        return cls(e, message=e.message, path=(e.path,) if e.path else ())
 
 
 class _BaseXmlValidator(BaseSchemabasedValidator, ABC):

--- a/tests/test_validation_json.py
+++ b/tests/test_validation_json.py
@@ -113,6 +113,32 @@ class TestJsonValidator(TestCase):
             self.assertIsNotNone(validation_error.data)
 
 
+
+    def test_validation_error_has_useful_message_and_path(self) -> None:
+        validator = JsonValidator(SchemaVersion.V1_6)
+        test_data = '{"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1, "metadata": {"timestamp": true}}'
+        try:
+            validation_error = validator.validate_str(test_data)
+        except MissingOptionalDependencyException:
+            self.skipTest('MissingOptionalDependencyException')
+        self.assertIsNotNone(validation_error)
+        assert validation_error is not None
+        self.assertTrue(validation_error.message)
+        self.assertEqual(('metadata', 'timestamp'), validation_error.path)
+        self.assertNotEqual(str(validation_error.data), str(validation_error))
+
+    def test_validation_error_prefers_nested_context_message(self) -> None:
+        validator = JsonValidator(SchemaVersion.V1_6)
+        test_data = '{"bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1, "components": [{"type": "library", "name": "demo", "version": 1}]}'
+        try:
+            validation_error = validator.validate_str(test_data)
+        except MissingOptionalDependencyException:
+            self.skipTest('MissingOptionalDependencyException')
+        self.assertIsNotNone(validation_error)
+        assert validation_error is not None
+        self.assertEqual(('components', 0, 'version'), validation_error.path)
+        self.assertIn('is not of type', validation_error.message)
+
 @ddt
 class TestJsonStrictValidator(TestCase):
 

--- a/tests/test_validation_xml.py
+++ b/tests/test_validation_xml.py
@@ -111,3 +111,17 @@ class TestXmlValidator(TestCase):
         self.assertGreater(len(validation_errors), 0)
         for validation_error in validation_errors:
             self.assertIsNotNone(validation_error.data)
+
+    def test_validation_error_has_useful_message_and_path(self) -> None:
+        validator = XmlValidator(SchemaVersion.V1_6)
+        test_data = '<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1"><metadata><timestamp>not-a-date</timestamp></metadata></bom>'
+        try:
+            validation_error = validator.validate_str(test_data)
+        except MissingOptionalDependencyException:
+            self.skipTest('MissingOptionalDependencyException')
+        self.assertIsNotNone(validation_error)
+        assert validation_error is not None
+        self.assertTrue(validation_error.message)
+        self.assertTrue(validation_error.path)
+        self.assertNotEqual(str(validation_error.data), str(validation_error))
+


### PR DESCRIPTION
### Motivation
- Provide a stable, safe presentation of validation failures so callers (UIs/tools) can display actionable messages instead of raw backend error objects.
- Make nested JSON schema failures more useful by preferring the most relevant `jsonschema` context error when available.
- Normalize XML validation log entries into the same `message`/`path` shape used for JSON.

### Description
- Extend `ValidationError` with normalized `message` and `path` attributes and update `__str__`/`__repr__` to present the human-facing message instead of raw backend data. (`cyclonedx/validation/__init__.py`)
- Implement logic in `JsonValidationError._make_from_jsve` to choose the most relevant nested `jsonschema` context error and populate `message` and `path`. (`cyclonedx/validation/json.py`)
- Map lxml validation log entries to `ValidationError(message=..., path=...)` in `XmlValidationError._make_from_xle`. (`cyclonedx/validation/xml.py`)
- Add regression tests that assert `ValidationError` exposes `message` and `path` for JSON and XML validators and that JSON error selection prefers nested context messages. (`tests/test_validation_json.py`, `tests/test_validation_xml.py`)

### Testing
- Ran `python -m pytest tests/test_validation_json.py tests/test_validation_xml.py`, all tests passed (1623 passed).
- The new regression tests for message/path extraction passed as part of the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35233cde08323985d38cb5e769832)