### PR TITLE
docs: Add SUGGESTIONS.md for non-breaking changes

### DIFF
--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -1,0 +1,34 @@
+# Non-Breaking Improvement Suggestions
+
+Here are some suggestions for non-breaking changes to improve the codebase quality:
+
+## 1. Documentation Improvements
+- Class `ComponentBuilder` in `cyclonedx/contrib/component/builders.py` is missing a docstring.
+- Class `HashTypeFactory` in `cyclonedx/contrib/hash/factories.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `get_schema_version` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Function `schema_version_enum` in `cyclonedx/schema/schema.py` is missing a docstring.
+- Class `PackageUrl` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Class `UrnUuidHelper` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `serialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `deserialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `serialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `deserialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `serialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- Function `deserialize` in `cyclonedx/serialization/__init__.py` is missing a docstring.
+- ... and 461 more docstring improvements.
+
+## 2. Typing Improvements
+
+## 3. General Non-Breaking Suggestions
+- **Performance/Refactoring:** Consider identifying deep nesting and simplifying code paths without changing public interfaces.
+- **Test Coverage:** Increase test coverage for Edge Cases in models.
+- **Error Messages:** Enhance the specificity of `Exception` messages in `cyclonedx/exception/__init__.py` to provide better debugging context to users.
+- **Deprecation warnings:** Add standard `DeprecationWarning` properly where needed without actually breaking the API.


### PR DESCRIPTION
The user requested to analyze the cyclonedx project and its technologies, set up the environment, run the CI fixers and generate suggestions. Specially suggestions which are not breaking changes since they have open breaking changes blocked from merging.

We explored the codebase and checked its technologies which are:
- `cyclonedx-python-lib` is an OWASP tool which implements the BOM (Bill of Materials) standard.
- Poetry is used as the package manager and dependency resolution.
- Tox is used to run tests sequentially, along with linter hooks such as mypy, flake8, bandit, etc.
- pre-commit is used for git hooks.

We ran `poetry install --all-extras` and verified all the hooks passed via `.pre-commit-config.yaml`, the github actions logic in `.github/workflows/python.yml`, and `tox`. We created a script to detect missing docstrings and typings and dumped them out to `SUGGESTIONS.md` under the root path to fulfill the request. The test suite also passes using `poetry run tox -e py312-allExtras`. We verified the hooks explicitly by using `pip install pre-commit && pre-commit run --all-files`.

---
*PR created automatically by Jules for task [2138611994474835863](https://jules.google.com/task/2138611994474835863) started by @saquibsaifee*